### PR TITLE
Fix test build warning on 32bit platforms

### DIFF
--- a/tests/test_litl_mapping_to_fxt.c
+++ b/tests/test_litl_mapping_to_fxt.c
@@ -79,7 +79,7 @@ int main() {
   fut_endup(filename);
   fut_done();
 
-  uint64_t size;
+  long size;
   FILE* fp = fopen(filename, "r");
   fseek(fp, 0L, SEEK_END);
   size = ftell(fp);

--- a/tests/test_litl_trace_size.c
+++ b/tests/test_litl_trace_size.c
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
 
   printf("Events are recorded and written in the %s file\n", filename);
 
-  litl_param_t size;
+  long size;
   FILE* fp = fopen(filename, "r");
   fseek(fp, 0L, SEEK_END);
   size = ftell(fp);


### PR DESCRIPTION
fseek returns a long anyway.